### PR TITLE
Fix #117 date/time selector

### DIFF
--- a/src/assets/css/custom.scss
+++ b/src/assets/css/custom.scss
@@ -52,8 +52,12 @@ label {
   }
 }
 
+.react-datepicker-popper {
+  z-index: 100;
+}
+
 .react-datepicker__time-list {
-  padding-left: 0;
+  padding: 0 !important;
 }
 
 .card-dull {
@@ -63,5 +67,17 @@ label {
     i {
       color: darken($brown-faded, 50%);
     }
+  }
+}
+
+@include media-breakpoint-up(md) {
+  .mobile {
+    display: none;
+  }
+}
+
+@include media-breakpoint-down(sm) {
+  .desktop {
+    display: none;
   }
 }

--- a/src/assets/css/custom.scss
+++ b/src/assets/css/custom.scss
@@ -52,10 +52,6 @@ label {
   }
 }
 
-.react-datepicker-popper {
-  z-index: 100;
-}
-
 .react-datepicker__time-list {
   padding: 0 !important;
 }

--- a/src/components/report/fieldset/SightingDetailsFieldset.js
+++ b/src/components/report/fieldset/SightingDetailsFieldset.js
@@ -24,7 +24,7 @@ const SightingDetailsFieldset = ({
     <fieldset>
       <legend>1. Sighting Details</legend>
 
-      <div className="form-group">
+      <div className="form-group desktop">
         <label htmlFor="dateTimeSighted">Date and time sighted</label>
         <DatePicker
           selected={ values.dateTimeSighted }
@@ -40,6 +40,30 @@ const SightingDetailsFieldset = ({
           timeCaption="time"
           className="form-control"
           id="dateTimeSighted"
+        />
+      </div>
+
+      <div className="form-group mobile">
+        <label htmlFor="dateTimeSightedMobile">Date and time sighted</label>
+        <input type='date'
+          value={ values.dateTimeSighted.format('YYYY-MM-DD') }
+          onChange={ e => {
+            e.preventDefault();
+            const time = values.dateTimeSighted.format('HH:mm');
+            const newDateTime = moment(`${e.target.value} ${time}`, 'YYYY-MM-DD HH:mm');
+            setFieldValue('dateTimeSighted', newDateTime);
+          }}
+          className="form-control"
+        />
+        <input type='time'
+          value={ values.dateTimeSighted.format('HH:mm') }
+          onChange={ e => {
+            e.preventDefault();
+            const date = values.dateTimeSighted.format('YYYY-MM-DD');
+            const newDateTime = moment(`${date} ${e.target.value}`, 'YYYY-MM-DD HH:mm');
+            setFieldValue('dateTimeSighted', newDateTime);
+          }}
+          className="form-control"
         />
       </div>
 


### PR DESCRIPTION
Fix #117 
Fixed CSS to show scroll bar on the right side of the time picker. 
Added separate date/time selector for mobile.

Date/time selector is just toggled based on screen width (768 px) so there will still be problem in certain cases e.g. iPhone X landscape (812 px) but it should clear the problem in most cases.
